### PR TITLE
Throw error when the root directory does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dorsale",
   "type": "module",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "./src/index.ts",
   "description": "Dorsale is a Bun-based TypeScript backend framework",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,13 @@ import { Node, walk } from "estree-walker";
 import { t } from "wint-js";
 import type { Server } from "bun";
 import qs from "fast-querystring";
+import { access } from "node:fs/promises";
+
+class DirectoryDoesNotExistsError extends Error {
+  constructor(rootDir: string) {
+    super(`Directory "${rootDir}" does not exist.`);
+  }
+}
 
 export type DorsaleApp = {
   server: Server;
@@ -84,6 +91,12 @@ export class Dorsale {
   }
 
   async getAllTsFiles() {
+    try {
+      await access(this.rootDir);
+    } catch {
+      throw new DirectoryDoesNotExistsError(this.rootDir);
+    }
+
     const glob = new Bun.Glob("**.ts");
     const res: string[] = [];
 

--- a/test/allMethodsController.test.ts
+++ b/test/allMethodsController.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mountApp } from "../src/app";
 import { AllMethodsController } from "./all-methods-controller/allMethodsController";
+import type { Server } from "bun";
 
 describe("All methods controller", () => {
-  let server, controller: AllMethodsController;
+  let server: Server, controller: AllMethodsController;
 
   beforeAll(async () => {
     const app = await mountApp({


### PR DESCRIPTION
* app.ts
  * New `DirectoryDoesNotExistsError` error to be thrown when the specified directory does not exist
  * Use `fs.access` to check directory's existence in `getAllTsFiles`
* allMethodsController.test.ts
  * Specify type of `server`